### PR TITLE
panel-headingのSNSリンクの位置合わせにcol-mdを使わない形式に変更

### DIFF
--- a/sample/css/style.css
+++ b/sample/css/style.css
@@ -189,11 +189,15 @@ li {
 }
 
 .section-heading {
-  height: 50px;
+  overflow: hidden;
 }
 .section-content-title {
+  display: inline;
   font-size: 30px;
-  margin-left: -20px;
+}
+.section-content-sns {
+  float: right;
+  padding-right: 20px;
 }
 
 .section-content-title .twitter-icon {

--- a/sample/index.html
+++ b/sample/index.html
@@ -88,7 +88,7 @@
         <div class="section-content">
           <div class="panel panel-default">
             <div class="panel-heading section-heading">
-              <h3 class="panel-title section-content-title col-md-9">○○高専「hogehoge」</h3><span class="col-md-3"><a href="//twitter.com/raryosu" class="twitter-icon"><i class="fa fa-twitter"></i> @hogehoge</a></span>
+              <h3 class="panel-title section-content-title">○○高専「hogehoge」</h3><span class="section-content-sns"><a href="//twitter.com/raryosu" class="twitter-icon"><i class="fa fa-twitter"></i> @hogehoge</a></span>
             </div>
             <div class="panel-body section-content-links">
               <p class="section-content-result text-warning">高専プロコン優勝, NAPROCK First Runner-up Prize</p>
@@ -101,7 +101,7 @@
           </div>
           <div class="panel panel-default">
             <div class="panel-heading section-heading">
-              <h3 class="panel-title section-content-title col-md-9">△△高専「piyo」</h3><span class="col-md-3"><a href="//twitter.com/raryosu" class="twitter-icon"><i class="fa fa-twitter"></i> @hogehoge</a></span>
+              <h3 class="panel-title section-content-title">△△高専「piyo」</h3><span class="section-content-sns"><a href="//twitter.com/raryosu" class="twitter-icon"><i class="fa fa-twitter"></i> @hogehoge</a></span>
             </div>
             <div class="panel-body section-content-links">
               <p class="section-content-result text-warning">高専プロコン準優勝</p>
@@ -113,7 +113,7 @@
           </div>
           <div class="panel panel-default">
             <div class="panel-heading section-heading">
-              <h3 class="panel-title section-content-title col-md-9">□□高専「unyo」</h3>
+              <h3 class="panel-title section-content-title">□□高専「unyo」</h3>
             </div>
             <div class="panel-body section-content-links">
               <p class="section-content-result text-warning">高専プロコン 敢闘賞</p>
@@ -128,7 +128,7 @@
         <div class="section-content">
           <div class="panel panel-default">
             <div class="panel-heading section-heading">
-              <h3 class="panel-title section-content-title col-md-9">○○高専「hogehoge」</h3><span class="col-md-3"><a href="//twitter.com/raryosu" class="twitter-icon"><i class="fa fa-twitter"></i> @hogehoge</a>
+              <h3 class="panel-title section-content-title">○○高専「hogehoge」</h3><span class="section-content-sns"><a href="//twitter.com/raryosu" class="twitter-icon"><i class="fa fa-twitter"></i> @hogehoge</a>
             </div>
             <div class="panel-body section-content-links">
               <p class="section-content-result text-warning">高専プロコン優勝</p>
@@ -147,7 +147,7 @@
         <div class="section-content">
           <div class="panel panel-default">
             <div class="panel-heading section-heading">
-              <h3 class="panel-title section-content-title col-md-9">○○高専「hogehoge」</h3><span class="col-md-3"><a href="//twitter.com/raryosu" class="twitter-icon"><i class="fa fa-twitter"></i> @hogehoge</a>
+              <h3 class="panel-title section-content-title">○○高専「hogehoge」</h3><span class="section-content-sns"><a href="//twitter.com/raryosu" class="twitter-icon"><i class="fa fa-twitter"></i> @hogehoge</a>
             </div>
             <div class="panel-body section-content-links">
               <p class="section-content-result text-warning">高専プロコン優勝, NAPROCK First Runner-up Prize</p>


### PR DESCRIPTION
狭いwindowサイズの時に位置が崩れていたため修正

デザイン的に問題なければ採用してくださいな
