### PR TITLE
管理者アカウントを作成するタスク

### DIFF
--- a/lib/tasks/operator.rake
+++ b/lib/tasks/operator.rake
@@ -1,0 +1,26 @@
+namespace :operator do
+  # rake operator:add [ADMIN=true]
+  desc '管理者のログイン情報を登録'
+  task add: :environment do
+    print 'id:'
+    id = STDIN.gets.chomp
+    raise 'Duplicate id' if Operator.where(identifier: id).exists?
+    operator = Operator.new
+    operator.identifier = id
+    operator.name = id
+    operator.position = 1 if ENV['ADMIN'] == 'true'
+
+    print 'password:'
+    pass = STDIN.noecho(&:gets).chomp
+    print "\nconfirm password:"
+    conf = STDIN.noecho(&:gets).chomp
+
+    if pass.present? && pass == conf
+      operator.password = pass
+      operator.save
+      print "\nSaved.\n"
+    else
+      print "\nError.\n"
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/NKMR6194/proconist.net/issues/58 のためのRakeタスク。

Webコンソールでアカウント作成可能にしてしまうと権限の管理が面倒なので、Rakeタスクに限定してしまう。