### PR TITLE
新着情報の順番と表示個数を直す

### DIFF
--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -6,7 +6,7 @@ class ContestsController < ApplicationController
   def show
     @contests = Contest.all.order(nth: :desc)
     @contest = Contest.includes(products: [:documents, :school, :prizes]).find_by(nth: params[:nth])
-    @histories = History.all.order(created_at: :desc)
+    @histories = History.order(id: :desc).limit(5)
     @histories_with_image = History.where.not(image_path: nil).where(label: 1).limit(5)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,7 @@ class PagesController < ApplicationController
   def index
     @contest = Contest.last
     @contests = Contest.includes(products: [:documents]).all.order(nth: :desc)
-    @histories = History.all.order(created_at: :desc)
+    @histories = History.order(id: :desc).limit(5)
     @histories_with_image = History.where.not(image_path: nil).where(label: 1).limit(5)
   end
 


### PR DESCRIPTION
`created_at` の値はどうせいじらないので、idの降順で取ってきちゃうようにした