### PR TITLE
Remove :rbenv_ruby in deploy script

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,6 @@ set :application, 'proconist.net'
 set :repo_url, 'git@github.com:NKMR6194/proconist.net.git'
 
 set :rbenv_type, :user
-set :rbenv_ruby, '2.3.5'
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp


### PR DESCRIPTION
https://github.com/capistrano/rbenv#defining-the-ruby-version

https://gitter.im/proconist-net/Lobby?at=59e2e3b1210ac26920e94edb

> あと `:rbenv_ruby` を省略すると `.ruby-version` を参照してくれるらしい。

> Alternatively, allow the remote host's rbenv to determine the appropriate Ruby version by omitting `:rbenv_ruby`. This approach is useful if you have a `.ruby-version` file in your project.
